### PR TITLE
[MAJOR] - Archive feature

### DIFF
--- a/phone-test/package.json
+++ b/phone-test/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6",
+    "subscriptions-transport-ws": "^0.11.0",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },

--- a/phone-test/src/gql/client/index.ts
+++ b/phone-test/src/gql/client/index.ts
@@ -131,6 +131,6 @@ const splitLink: ApolloLink = split(
 );
 
 export const client = new ApolloClient({
-  link: from([errorLink, authLink, httpLink]),
+  link: from([errorLink, authLink, splitLink]),
   cache: new InMemoryCache()
 });

--- a/phone-test/src/gql/client/index.ts
+++ b/phone-test/src/gql/client/index.ts
@@ -1,27 +1,40 @@
-import { ApolloClient, createHttpLink, from, fromPromise, InMemoryCache } from '@apollo/client';
+import {
+  ApolloClient,
+  ApolloLink,
+  createHttpLink,
+  from,
+  fromPromise,
+  InMemoryCache,
+  split
+} from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { onError } from '@apollo/client/link/error';
+import { WebSocketLink } from '@apollo/client/link/ws';
+import { getMainDefinition } from '@apollo/client/utilities';
+import { SubscriptionClient } from 'subscriptions-transport-ws'; // <- import this
 import tokenStorage from '../../helpers/tokenStorage';
 import { REFRESH_TOKEN } from '../mutations';
+import { RetryLink } from '@apollo/client/link/retry';
 
-const httpLink = createHttpLink({
-  uri: 'https://frontend-test-api.aircall.dev/graphql'
-});
+const url = {
+  http: 'https://frontend-test-api.aircall.dev/graphql',
+  ws: 'ws://frontend-test-api.aircall.dev/websocket'
+};
 
 let isRefreshingToken: boolean = false;
 
 const getRefreshedToken = async (): Promise<void> => {
-  // Set refresh token as the current access token to be used in the request from authLink
-  const refreshToken = tokenStorage.getRefreshToken();
-  if (refreshToken) {
-    tokenStorage.setAccessToken(refreshToken);
-  }
-
   /**
    * If we are already refreshing the token, return the current promise
    * to avoid sending multiple requests
    */
   if (isRefreshingToken) return;
+
+  // Set refresh token as the current access token to be used in the request from authLink
+  const refreshToken = tokenStorage.getRefreshToken();
+  if (refreshToken) {
+    tokenStorage.setAccessToken(refreshToken);
+  }
 
   isRefreshingToken = true;
 
@@ -45,14 +58,50 @@ const getRefreshedToken = async (): Promise<void> => {
   }
 };
 
-const errorLink = onError(({ graphQLErrors, operation, forward }) => {
+const wsClient = new SubscriptionClient(url.ws, {
+  lazy: true,
+  reconnect: true,
+  timeout: 40000,
+  connectionParams: () => {
+    return {
+      authorization: `Bearer ${tokenStorage.getAccessToken()}`
+    };
+  }
+});
+const wsLink = new WebSocketLink(wsClient);
+
+wsClient.onConnected(() => console.log('websocket connected!!'));
+wsClient.onDisconnected(() => console.log('websocket disconnected!!'));
+wsClient.onReconnected(() => console.log('websocket reconnected!!'));
+
+const httpLink: ApolloLink = createHttpLink({
+  uri: url.http
+});
+
+/**
+ * Auth link to add the access token to the request
+ */
+const authLink: ApolloLink = setContext((_, { headers }) => {
+  const accessToken = tokenStorage.getAccessToken();
+
+  // return the headers to the context so httpLink can read them
+  return {
+    headers: {
+      ...headers,
+      authorization: accessToken ? `Bearer ${accessToken}` : ''
+    }
+  };
+});
+
+/**
+ * Error link to handle errors
+ * If the error is a 401, we need to refresh the token
+ */
+const errorLink: ApolloLink = onError(({ graphQLErrors, operation, forward }) => {
   if (graphQLErrors) {
     for (let err of graphQLErrors) {
       const exception = err.extensions.exception as { status: number };
-      /**
-       * If the error is a 401, we need to refresh the token
-       * and retry the request
-       */
+
       if (exception && exception.status === 401) {
         return fromPromise(
           getRefreshedToken().catch(() => {
@@ -68,17 +117,18 @@ const errorLink = onError(({ graphQLErrors, operation, forward }) => {
   }
 });
 
-const authLink = setContext((_, { headers }) => {
-  const accessToken = tokenStorage.getAccessToken();
-
-  // return the headers to the context so httpLink can read them
-  return {
-    headers: {
-      ...headers,
-      authorization: accessToken ? `Bearer ${accessToken}` : ''
-    }
-  };
-});
+/**
+ * Split the link to use the websocket link for subscriptions
+ * and the http link for everything else
+ */
+const splitLink: ApolloLink = split(
+  ({ query }) => {
+    const definition = getMainDefinition(query);
+    return definition.kind === 'OperationDefinition' && definition.operation === 'subscription';
+  },
+  wsLink,
+  httpLink
+);
 
 export const client = new ApolloClient({
   link: from([errorLink, authLink, httpLink]),

--- a/phone-test/src/gql/client/index.ts
+++ b/phone-test/src/gql/client/index.ts
@@ -14,11 +14,10 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { SubscriptionClient } from 'subscriptions-transport-ws'; // <- import this
 import tokenStorage from '../../helpers/tokenStorage';
 import { REFRESH_TOKEN } from '../mutations';
-import { RetryLink } from '@apollo/client/link/retry';
 
 const url = {
   http: 'https://frontend-test-api.aircall.dev/graphql',
-  ws: 'ws://frontend-test-api.aircall.dev/websocket'
+  ws: 'wss://frontend-test-api.aircall.dev/websocket'
 };
 
 let isRefreshingToken: boolean = false;

--- a/phone-test/src/gql/mutations/archiveCall.ts
+++ b/phone-test/src/gql/mutations/archiveCall.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+import { CALL_FIELDS } from '../fragments';
+
+export const ARCHIVE_CALL = gql`
+  ${CALL_FIELDS}
+  mutation ArchiveCall($id: ID!) {
+    archiveCall(id: $id) {
+      ...CallFields
+    }
+  }
+`;

--- a/phone-test/src/gql/mutations/index.ts
+++ b/phone-test/src/gql/mutations/index.ts
@@ -1,2 +1,3 @@
 export * from './login';
 export * from './refreshToken';
+export * from './archiveCall';

--- a/phone-test/src/gql/queries/user.ts
+++ b/phone-test/src/gql/queries/user.ts
@@ -3,7 +3,7 @@ import { USER_FIELDS } from '../fragments/user';
 
 export const GET_USER = gql`
   ${USER_FIELDS}
-  query ME {
+  query Me {
     me {
       ...UserFields
     }

--- a/phone-test/src/gql/subscriptions/callsSubscription.ts
+++ b/phone-test/src/gql/subscriptions/callsSubscription.ts
@@ -1,10 +1,12 @@
 import { gql } from '@apollo/client';
+import { CALL_FIELDS } from '../fragments';
 
-const CALLS_SUBSCRIPTION = gql`
-  subscription onUpdateCall($postID: ID!) {
-    commentAdded(postID: $postID) {
-      id
-      content
+export const CALLS_SUBSCRIPTION = gql`
+  ${CALL_FIELDS}
+
+  subscription onUpdateCal {
+    onUpdatedCall {
+      ...CallFields
     }
   }
 `;

--- a/phone-test/src/gql/subscriptions/callsSubscription.ts
+++ b/phone-test/src/gql/subscriptions/callsSubscription.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+const CALLS_SUBSCRIPTION = gql`
+  subscription onUpdateCall($postID: ID!) {
+    commentAdded(postID: $postID) {
+      id
+      content
+    }
+  }
+`;

--- a/phone-test/src/gql/subscriptions/index.ts
+++ b/phone-test/src/gql/subscriptions/index.ts
@@ -1,0 +1,1 @@
+export * from './callsSubscription';

--- a/phone-test/src/pages/CallDetails.tsx
+++ b/phone-test/src/pages/CallDetails.tsx
@@ -1,9 +1,9 @@
+import { Box, Button, Spacer, Typography } from '@aircall/tractor';
 import { useQuery } from '@apollo/client';
 import { useNavigate, useParams } from 'react-router-dom';
-import { GET_CALL_DETAILS } from '../gql/queries/getCallDetails';
-import { Box, Button, ChevronLeftOutlined, Spacer, Typography } from '@aircall/tractor';
-import { formatDate, formatDuration } from '../helpers/dates';
 import Spinner from '../components/Spinner';
+import { GET_CALL_DETAILS } from '../gql/queries/getCallDetails';
+import { formatDate, formatDuration } from '../helpers/dates';
 
 export const CallDetailsPage = () => {
   const { callId } = useParams();

--- a/phone-test/src/pages/CallsList.tsx
+++ b/phone-test/src/pages/CallsList.tsx
@@ -22,6 +22,7 @@ import styled from 'styled-components';
 import Spinner from '../components/Spinner';
 import { ARCHIVE_CALL } from '../gql/mutations';
 import { PAGINATED_CALLS } from '../gql/queries';
+import { CALLS_SUBSCRIPTION } from '../gql/subscriptions';
 import { formatDate, formatDuration } from '../helpers/dates';
 
 export const PaginationWrapper = styled.div`
@@ -48,12 +49,16 @@ export const CallsListPage = () => {
   const pageQueryParams = search.get('page');
   const activePage = !!pageQueryParams ? parseInt(pageQueryParams) : 1;
 
-  const { loading, error, data } = useQuery(PAGINATED_CALLS, {
+  const { loading, error, data, subscribeToMore } = useQuery(PAGINATED_CALLS, {
     variables: {
       offset: (activePage - 1) * CALLS_PER_PAGE,
       limit: CALLS_PER_PAGE
     }
     // onCompleted: () => handleRefreshToken(),
+  });
+
+  subscribeToMore({
+    document: CALLS_SUBSCRIPTION
   });
 
   if (loading) return <Spinner />;

--- a/phone-test/src/pages/CallsList.tsx
+++ b/phone-test/src/pages/CallsList.tsx
@@ -1,19 +1,28 @@
-import { useQuery } from '@apollo/client';
-import styled from 'styled-components';
-import { PAGINATED_CALLS } from '../gql/queries';
 import {
-  Grid,
-  Icon,
-  Typography,
-  Spacer,
+  ArchiveFilled,
+  ArchiveOutlined,
   Box,
   DiagonalDownOutlined,
   DiagonalUpOutlined,
-  Pagination
+  Flex,
+  Grid,
+  Icon,
+  IconButton,
+  Pagination,
+  Spacer,
+  SpinnerOutlined,
+  Tooltip,
+  Typography,
+  useToast
 } from '@aircall/tractor';
-import { formatDate, formatDuration } from '../helpers/dates';
+import { useMutation, useQuery } from '@apollo/client';
+import { useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
 import Spinner from '../components/Spinner';
+import { ARCHIVE_CALL } from '../gql/mutations';
+import { PAGINATED_CALLS } from '../gql/queries';
+import { formatDate, formatDuration } from '../helpers/dates';
 
 export const PaginationWrapper = styled.div`
   > div {
@@ -25,10 +34,17 @@ export const PaginationWrapper = styled.div`
 `;
 
 const CALLS_PER_PAGE = 5;
+const ARCHIVE_OPERATION = 'ARCHIVE_OPERATION';
 
 export const CallsListPage = () => {
   const [search] = useSearchParams();
   const navigate = useNavigate();
+  const { showToast, removeToast } = useToast();
+  const [archiveMutation] = useMutation(ARCHIVE_CALL);
+
+  // Ref to keep track of the call being archived
+  let archivingCallId = useRef<string | undefined>();
+
   const pageQueryParams = search.get('page');
   const activePage = !!pageQueryParams ? parseInt(pageQueryParams) : 1;
 
@@ -52,6 +68,35 @@ export const CallsListPage = () => {
 
   const handlePageChange = (page: number) => {
     navigate(`/calls/?page=${page}`);
+  };
+
+  const handleArchiveCall = (call: Call) => {
+    const { id } = call;
+
+    removeToast(ARCHIVE_OPERATION);
+    archivingCallId.current = id;
+
+    archiveMutation({
+      variables: {
+        id
+      },
+      onCompleted: ({ archiveCall }) => {
+        archivingCallId.current = undefined;
+        showToast({
+          id: ARCHIVE_OPERATION,
+          message: archiveCall.is_archived ? 'Call archived' : 'Call unarchived',
+          variant: 'success'
+        });
+      },
+      onError: () => {
+        archivingCallId.current = undefined;
+        showToast({
+          id: ARCHIVE_OPERATION,
+          message: 'Error while archiving call',
+          variant: 'error'
+        });
+      }
+    });
   };
 
   return (
@@ -81,6 +126,8 @@ export const CallsListPage = () => {
               borderRadius={16}
               cursor="pointer"
               onClick={() => handleCallOnClick(call.id)}
+              onMouseOver={e => (e.currentTarget.style.backgroundColor = '#E5E5E5')}
+              onMouseLeave={e => (e.currentTarget.style.backgroundColor = '#F7F7F7')}
             >
               <Grid
                 data-testid={`call-item`}
@@ -99,12 +146,34 @@ export const CallsListPage = () => {
                   <Typography variant="body">{title}</Typography>
                   <Typography variant="body2">{subtitle}</Typography>
                 </Box>
-                <Box>
-                  <Typography variant="caption" textAlign="right">
-                    {duration}
-                  </Typography>
-                  <Typography variant="caption">{date}</Typography>
-                </Box>
+
+                <Flex alignItems="center">
+                  <Box>
+                    <Typography variant="caption" textAlign="right">
+                      {duration}
+                    </Typography>
+                    <Typography variant="caption">{date}</Typography>
+                  </Box>
+
+                  <Spacer space="s" ml="12px">
+                    <Tooltip title={call.is_archived ? 'Unarchive' : 'Archive'}>
+                      {archivingCallId.current === call.id ? (
+                        <Icon key={call.id} component={SpinnerOutlined} spin />
+                      ) : (
+                        <IconButton
+                          key={call.id}
+                          size={24}
+                          component={call.is_archived ? ArchiveFilled : ArchiveOutlined}
+                          color="#01B288"
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleArchiveCall(call);
+                          }}
+                        />
+                      )}
+                    </Tooltip>
+                  </Spacer>
+                </Flex>
               </Grid>
               <Box px={4} py={2}>
                 <Typography variant="caption">{notes}</Typography>

--- a/phone-test/yarn.lock
+++ b/phone-test/yarn.lock
@@ -3156,6 +3156,11 @@ babel-preset-react-app@^10.0.1:
     babel-plugin-macros "^3.1.0"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
 
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -4815,6 +4820,11 @@ eventemitter2@6.4.7:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
   integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
 eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -6137,6 +6147,11 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterall@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jake@^10.8.5:
   version "10.8.5"
@@ -9589,6 +9604,17 @@ stylehacks@^5.1.1:
     browserslist "^4.21.4"
     postcss-selector-parser "^6.0.4"
 
+subscriptions-transport-ws@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz#baf88f050cba51d52afe781de5e81b3c31f89883"
+  integrity sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0 || ^6.0.0 || ^7.0.0"
+
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -9659,6 +9685,11 @@ svgo@^2.7.0:
     csso "^4.2.0"
     picocolors "^1.0.0"
     stable "^0.1.8"
+
+symbol-observable@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-observable@^4.0.0:
   version "4.0.0"
@@ -10591,7 +10622,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.4.6:
+"ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==


### PR DESCRIPTION
### Description
This **PR** aims to allow Aircall users to **archive** their calls through a new action available in the calls list.

To perform actions more acurratly and considering that calls can be update from other origins, we need to access the most fresh call data, to acomplish that we need to be notified from those changes by having a **bi-directional**  comunitcation with the server provided by [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) technology.


#### Changelog

- Setup `Apollo` client to support subscriptions
- Improve `Apollo` client to handle token revalidation
- Add `ARCHIVE_CALL ` mutation
- Add `CALLS_SUBSCRIPTION ` subscription
- Support **Archive** operation in `CallsList` 
- Support **Call subscription** update in `CallsList`

#### Steps to test this feature

1. Login with your Aircall account in the PR deployment preview.
2. Open a new tab and access the same PR deployment preview
3. Choose an `Unarchived` call and click on the **archive** button
4. Verify that the status changed to `Unarchived` and a new **success** toast appeared
5. Verify that in the new tab the same call changes to the same state.

#### Note
The archive funcionality works as a toogle operation, which means you can `Archived` and `Unarchived` a call.
